### PR TITLE
Remove Mop integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "test": "npm run build && npm run test:node && npm run test:phantom && npm run lint",
     "test:node": "jasminum test",
     "test:phantom": "(cd node_modules/mr && jasminum-phantom test)",
-    "lint": "jshint .",
-    "integration": "MOP_VERSION=^0.13 MR_VERSION=. mop-integration"
+    "lint": "jshint ."
   },
   "bin": {
     "mr": "bin/mr.js",
@@ -54,7 +53,6 @@
     "jasminum": "^2.0.7",
     "joey": "^2.0.1",
     "jshint": "^2.6.0",
-    "mop-integration": "git://github.com/montagejs/mop-integration.git#master",
     "q-io": "^2.0.6",
     "query-string": "^1.0.0",
     "wd": "^0.3.11",


### PR DESCRIPTION
My intention is to rewrite Mop and build it directly into Mr. The new Mop will build directly to .git. Mop would need an overhaul for Mr v2 regardless.

cc @Stuk 
